### PR TITLE
Add group support on Mixpanel

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -281,6 +281,62 @@ Mixpanel.prototype.increment = function(track, fn){
 };
 
 /**
+ * Group support for Mixpanel by adding users with a property called
+ *  isGroup set to True and forcing the prefix 'group.' on $distinct_id
+ *
+ * @param {Group} group
+ * @param {Function} fn
+ * @api public
+ */
+
+Mixpanel.prototype.group = function(group, fn){
+  if (!this.settings.people) return tick(fn);
+  var json = group.json();
+  var traits = json.traits || {};
+  var self = this;
+  var groupId = 'group.' + group.groupId();
+
+  traits['$name'] = traits['name'];
+  traits['isGroup'] = true;
+  object.del(traits,'name');
+
+  var group_payload = {
+    $distinct_id: groupId, // the primary group id
+    $token: this.settings.token,
+    $time: group.timestamp().getTime(),
+    $set: stringifyValues(traits), // set all the traits on group
+    $ip: 0,
+    $ignore_time: false, //enable Last Seen for groups
+    mp_lib: 'Segment: ' + identify.library().name
+  };
+
+  this
+    .get('/engage')
+    .query({ ip: 0 })
+    .query({ verbose: 1 })
+    .query({ data: b64encode(group_payload) })
+    .end(this.handle(function(err){
+        if (err) return fn(err);
+
+        var user_payload = {
+          $distinct_id: group.userId(), // the primary id
+          $token: self.settings.token,
+          $union: stringifyValues({ "groups" : [groupId]})
+        };
+
+        self
+          .get('/engage')
+          .query({ ip: 0 })
+          .query({ verbose: 1 })
+          .query({ data: b64encode(user_payload) })
+          .end(self._parseResponse(fn));
+
+      })
+    );
+
+};
+
+/**
  * Common function for parsing the response from a mixpanel call.
  *
  * @param {Function} fn


### PR DESCRIPTION
This patch brings group() support to Mixpanel, by adding users with a property called isGroup set to true and forcing the prefix 'group.' on $distinct_id so that it doesn't conflict with normal users.

It additionally appends a property called "groups" to user properties, that is a unique set of group IDs, making it possible to go from a user to the groups.

This is extremely useful for SaaS businesses with pricing per organisation, enabling analytics such as how often an organisation is active, revenue per organisation, messaging to users of an organisation through Mixpanel, etc.

The biggest problem with this patch, however, is that I have not found a way to test by running it. I am not familiar with Segment's architecture, and less so with node.js, however I'm keen to accept reviews and make amendments where needed to make this patch work.