### PR TITLE
remove browser and os version from mapping

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -434,8 +434,8 @@ function formatProperties(track, settings){
     var parsed = parse(userAgent);
     var browser = parsed.browser
     var os = parsed.os;
-    if (browser) properties.$browser = browser.name + ' ' + browser.version;
-    if (os) properties.$os = os.name + ' ' + os.version;
+    if (browser) properties.$browser = browser.name;
+    if (os) properties.$os = os.name;
   }
   return properties;
 }

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -12,7 +12,8 @@
       "query": "analytics"
     },
     "context": {
-      "ip": "10.0.0.1"
+      "ip": "10.0.0.1",
+      "userAgent": "Mozilla/5.0 (PlayBook; U; RIM Tablet OS 1.0.0; en-US) AppleWebKit/534.11 (KHTML, like Gecko) Version/7.1.0.7 Safari/534.11"
     }
   },
   "output": {
@@ -20,6 +21,8 @@
     "properties": {
       "$search_engine": "google",
       "$referrer": "someone",
+      "$browser": "Safari",
+      "$os": "RIM Tablet OS",
       "$username": "jd",
       "email": "jd@example.com",
       "mp_name_tag": "user-id",


### PR DESCRIPTION
This is to match the behavior of mixpanel.js, which does NOT append the browser or OS version. I didn't see any tests that were checking browser so I only updated the integration mapper.

Some screen grabs from Mixpanel of how the browser appears via mixpanel.js (and what we should be matching).

## Browser

![](http://content.screencast.com/users/DirtyAnalytics/folders/Jing/media/a26ccc9b-1745-4ad5-b047-6aa1e6d7df37/00000237.png)

## OS

![](http://content.screencast.com/users/DirtyAnalytics/folders/Jing/media/c1a54e59-04e6-4b70-ac9b-f74579644096/00000236.png)
