### PR TITLE
Remap traits.token to not conflict with Mixpanels internal keywords.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ Mixpanel.ensure(function(msg, settings){
 
 Mixpanel.prototype.identify = function(identify, fn){
   if (!this.settings.people) return tick(fn);
-  
+
   var batch = new Batch;
   batch.throws(true)
   var self = this;
@@ -372,7 +372,9 @@ var traitAliases = {
   lastSeen: '$last_seen',
   name: '$name',
   username: '$username',
-  phone: '$phone'
+  phone: '$phone',
+  // Token is reserved by Mixpanel, so remap it.
+  token: 'trait_token'
 };
 
 /**

--- a/test/fixtures/track-context.json
+++ b/test/fixtures/track-context.json
@@ -33,6 +33,9 @@
         "wifi": false,
         "bluetooth": false
       },
+      "traits": {
+        "token": "my-token"
+      },
       "ip": "10.0.0.1"
     }
   },
@@ -59,6 +62,7 @@
       "time": 1388534400,
       "id": "user-id",
       "token": "50912cd33fd82225ab5ae1c563bd5a7e",
+      "trait_token": "my-token",
       "mp_name_tag": "user-id",
       "distinct_id": "user-id"
     }


### PR DESCRIPTION
cc @bbeaird 