### PR TITLE
map to way more context props and traits

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -135,7 +135,6 @@ Mixpanel.prototype.track = function(track, fn){
   };
 
   extend(payload.properties, superProperties(track, this.settings));
-
   var query = {
     verbose: 1,
     data: b64encode(payload),
@@ -371,7 +370,7 @@ var traitAliases = {
   email: '$email',
   firstName: '$first_name',
   lastName: '$last_name',
-  lastSeen: '$last_seen',
+  lastSeen: '$last_seen', // This should be removed since docs say not to set this manually or can't be set
   name: '$name',
   username: '$username',
   phone: '$phone',
@@ -390,6 +389,7 @@ var traitAliases = {
 function formatTraits(identify){
   // Get traits, renaming any special Mixpanel properties from their Segment names
   var traits = identify.traits(traitAliases) || {};
+  var userAgent = identify.userAgent();
 
   // Delete any Segment trait names; they've now been renamed to Mixpanel names
   each(traitAliases, function(_, key) {
@@ -398,12 +398,18 @@ function formatTraits(identify){
     }});
   });
 
+  if (userAgent) extend(traits, formatUserAgent(userAgent));
+
   // Facade automatically converts `name` to `firstName` and `lastName`, so we don't need this
   delete traits.$name;
+  // Format timestamp
   // https://mixpanel.com/help/reference/http#people-special-properties, `$created` section
   if (traits.$created) {
     traits.$created = formatDate(traits.$created);
   }
+
+  // Map semantic mobile context properties
+  extend(traits, formatMobileSpecific(identify));
 
   stringifyValues(traits);
   return traits;
@@ -423,30 +429,22 @@ function formatProperties(track, settings){
   var properties = track.properties() || {};
   var identify = track.identify();
   var userAgent = track.userAgent();
+  var campaign = track.proxy('context.campaign') || {};
+  var app = track.proxy('context.app') || {};
+
   extend(properties, {
-    token: settings.token,
+    $app_release: app.build,
+    $app_version: app.version,
+    $current_url: track.proxy('context.page.url'),
+    $device: track.proxy('context.device.name'),
     distinct_id: track.userId() || track.sessionId(),
-    time: time(track.timestamp()),
+    ip: track.ip(),
     mp_lib: 'Segment: ' + track.library().name,
-    $lib_version: track.library().version,
-    $search_engine: track.proxy('properties.searchEngine'),
     $referrer: track.referrer(),
-    $username: track.username(),
-    $os: track.proxy('context.os.name'),
-    $os_version: track.proxy('context.os.version'),
-    $manufacturer: track.proxy('context.device.manufacturer'),
-    $screen_dpi: track.proxy('context.screen.density'),
-    $screen_height: track.proxy('context.screen.height'),
-    $screen_width: track.proxy('context.screen.width'),
-    $bluetooth_enabled: track.proxy('context.network.bluetooth'),
-    $has_telephone: track.proxy('context.network.cellular'),
-    $carrier: track.proxy('context.network.carrier'),
-    $app_version: track.proxy('context.app.version'),
-    $wifi: track.proxy('context.network.wifi'),
-    $brand: track.proxy('context.device.brand'),
-    $model: track.proxy('context.device.model'),
-    $app_release: track.proxy('context.app.build'),
-    ip: track.ip()
+    $search_engine: track.proxy('properties.searchEngine'),
+    time: time(track.timestamp()),
+    token: settings.token,
+    $username: track.username()
   });
 
   // Remove possible duplicate properties.
@@ -460,17 +458,101 @@ function formatProperties(track, settings){
     || identify.userId()
     || identify.sessionId();
 
+  if (userAgent) extend(properties, formatUserAgent(userAgent));
+
+  // Map mobile specific special props
+  extend(properties, formatMobileSpecific(track));
+
+  // Map UTM params
+  if (campaign) {
+    properties.utm_name = campaign.name;
+    properties.utm_source = campaign.source;
+    properties.utm_medium = campaign.medium;
+    properties.utm_term = campaign.term;
+    properties.utm_content = campaign.content;
+  }
+
+  // Strip null/undefined values
   properties = reject(properties);
   stringifyValues(properties);
 
-  if (userAgent) {
-    var parsed = parse(userAgent);
-    var browser = parsed.browser
-    var os = parsed.os;
-    if (browser) properties.$browser = browser.name;
-    if (os) properties.$os = os.name;
-  }
   return properties;
+}
+
+/**
+ * Format userAgent properties
+ *
+ * https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default
+ *
+ * @param {string} data
+ * @return {Object}
+ * @api private
+ */
+
+function formatUserAgent(data){
+  var ret = {};
+  var parsed = parse(data);
+  var browser = parsed.browser;
+  var os = parsed.os;
+
+  if (browser) {
+    ret.$browser = browser.name;
+    ret.$browser_version = browser.version;
+  }
+
+  return ret;
+}
+
+/**
+ * Format mobile specific properties
+ * https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default
+ *
+ * @param {msg} msg
+ * @return {Object}
+ * @api private
+ */
+
+function formatMobileSpecific(track) {
+  var device = track.proxy('context.device') || {};
+  var app = track.proxy('context.app') || {};
+  var os = track.proxy('context.os') || {};
+  var network = track.proxy('context.network') || {};
+  var screen = track.proxy('context.screen') || {};
+  var ret = {};
+
+  ret.$carrier = network.carrier;
+  ret.$manufacturer = device.manufacturer;
+  ret.$model = device.model;
+  ret.$os = os.name;
+  ret.$os_version = os.version;
+  ret.$screen_height = screen.height;
+  ret.$screen_width = screen.width;
+  ret.$wifi = network.wifi
+  // ret.$brand = device.model; what should this be
+
+
+  switch (device.type) {
+    case 'iOS':
+      ret.$ios_ifa = device.advertisingId;
+      ret.$ios_device_model = device.model;
+      ret.$ios_app_release = app.build;
+      ret.$ios_app_version = app.version;
+      ret.$ios_version = os.version;
+      break;
+    case 'android':
+      ret.$screen_dpi = screen.density;
+      ret.$bluetooth_enabled = network.bluetooth;
+      ret.$has_telephone = network.cellular;
+      ret.$android_version_code = app.version;
+      ret.$android_app_version = app.version;
+      ret.$android_os = os.name;
+      ret.$android_os_version = os.version;
+      ret.$android_model = device.model;
+      ret.$android_manufacturer = device.manufacturer;
+      // ret.$android_brand = device.manufacturer; ?? what should this be
+      break;
+  }
+  return ret;
 }
 
 /**

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -13,7 +13,11 @@
     },
     "context": {
       "ip": "10.0.0.1",
-      "userAgent": "Mozilla/5.0 (PlayBook; U; RIM Tablet OS 1.0.0; en-US) AppleWebKit/534.11 (KHTML, like Gecko) Version/7.1.0.7 Safari/534.11"
+      "userAgent": "Mozilla/5.0 (PlayBook; U; RIM Tablet OS 1.0.0; en-US) AppleWebKit/534.11 (KHTML, like Gecko) Version/7.1.0.7 Safari/534.11",
+      "os": {
+        "name": "iPhone OS",
+        "version": "8.1.3"
+      }
     }
   },
   "output": {
@@ -22,7 +26,9 @@
       "$search_engine": "google",
       "$referrer": "someone",
       "$browser": "Safari",
-      "$os": "RIM Tablet OS",
+      "$os": "iPhone OS",
+      "$os_version": "8.1.3",
+      "$browser_version": "7.1.0.7",
       "$username": "jd",
       "email": "jd@example.com",
       "mp_name_tag": "user-id",

--- a/test/fixtures/track-context.json
+++ b/test/fixtures/track-context.json
@@ -5,66 +5,105 @@
     "event": "my-event",
     "timestamp": "2014",
     "context": {
-      "library": {
-        "version": "2.0.0",
-        "name": "analytics-android"
-      },
-      "os": {
-        "name": "Android KitKat",
-        "version": "4.4.2"
-      },
-      "device": {
-        "manufacturer": "Samsung",
-        "brand": "generic",
-        "model": "Galaxy Nexus"
-      },
-      "screen": {
-        "density": 480,
-        "height": 1776,
-        "width": 1080
-      },
       "app": {
-        "version": "2.0.0-SNAPSHOT",
-        "build": "1.7.38"
-      },
-      "network": {
-        "cellular": true,
-        "carrier": "Sprint",
-        "wifi": false,
-        "bluetooth": false
-      },
-      "traits": {
-        "token": "my-token"
-      },
-      "ip": "10.0.0.1"
+      "name": "InitechGlobal",
+      "version": "545",
+      "build": "3.0.1.545"
+    },
+    "campaign": {
+      "name": "TPS Innovation Newsletter",
+      "source": "Newsletter",
+      "medium": "email",
+      "term": "tps reports",
+      "content": "image link"
+    },
+    "device": {
+      "id": "B5372DB0-C21E-11E4-8DFC-AA07A5B093DB",
+      "advertisingId": "7A3CBEA0-BDF5-11E4-8DFC-AA07A5B093DB",
+      "adTrackingEnabled": true,
+      "manufacturer": "Apple",
+      "model": "iPhone7,2",
+      "name": "maguro",
+      "type": "iOS",
+      "token": "ff15bc0c20c4aa6cd50854ff165fd265c838e5405bfeb9571066395b8c9da449"
+    },
+    "ip": "8.8.8.8",
+    "library": {
+      "name": "analytics.js",
+      "version": "2.11.1"
+    },
+    "locale": "nl-NL",
+    "location": {
+      "city": "San Francisco",
+      "country": "United States",
+      "latitude": 40.2964197,
+      "longitude": -76.9411617,
+      "speed": 0
+    },
+    "network": {
+      "bluetooth": false,
+      "carrier": "T-Mobile NL",
+      "cellular": true,
+      "wifi": false
+    },
+    "os": {
+      "name": "iPhone OS",
+      "version": "8.1.3"
+    },
+    "page": {
+      "path": "/academy/",
+      "referrer": "",
+      "search": "",
+      "title": "Analytics Academy",
+      "url": "https://segment.com/academy/"
+    },
+    "referrer": {
+      "id": "ABCD582CDEFFFF01919",
+      "type": "dataxu"
+    },
+    "screen": {
+      "width": 320,
+      "height": 568,
+      "density": 2
+    },
+    "timezone": "Europe/Amsterdam",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1"
     }
   },
   "output": {
     "event": "my-event",
-    "properties": {
-      "mp_lib": "Segment: analytics-android",
-      "$lib_version": "2.0.0",
-      "$os": "Android KitKat",
-      "$os_version": "4.4.2",
-      "$manufacturer": "Samsung",
-      "$brand": "generic",
-      "$model": "Galaxy Nexus",
-      "$screen_dpi": 480,
-      "$screen_height": 1776,
-      "$screen_width": 1080,
-      "$app_version": "2.0.0-SNAPSHOT",
-      "$app_release": "1.7.38",
-      "$has_telephone": true,
-      "$carrier": "Sprint",
-      "$wifi": false,
-      "$bluetooth_enabled": false,
-      "ip": "10.0.0.1",
+    "properties": { 
+      "$app_release": "3.0.1.545",
+      "$app_version": "545",
+      "$current_url": "https://segment.com/academy/",
+      "$device": "maguro",
+      "distinct_id": "user-id",
+      "ip": "8.8.8.8",
+      "mp_lib": "Segment: analytics.js",
       "time": 1388534400,
-      "id": "user-id",
       "token": "50912cd33fd82225ab5ae1c563bd5a7e",
-      "trait_token": "my-token",
       "mp_name_tag": "user-id",
-      "distinct_id": "user-id"
+      "$browser": "Mobile Safari",
+      "$browser_version": "9.0",
+      "$carrier": "T-Mobile NL",
+      "$manufacturer": "Apple",
+      "$model": "iPhone7,2",
+      "$os": "iPhone OS",
+      "$os_version": "8.1.3",
+      "$screen_height": 568,
+      "$screen_width": 320,
+      "$wifi": false,
+      "$ios_ifa": "7A3CBEA0-BDF5-11E4-8DFC-AA07A5B093DB",
+      "$ios_device_model": "iPhone7,2",
+      "$ios_app_release": "3.0.1.545",
+      "$ios_app_version": "545",
+      "$ios_version": "8.1.3",
+      "utm_name": "TPS Innovation Newsletter",
+      "utm_source": "Newsletter",
+      "utm_medium": "email",
+      "utm_term": "tps reports",
+      "utm_content": "image link",
+      "id": "user-id"
     }
   }
 }


### PR DESCRIPTION
Following this docs from Mixpanel:

https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default

and our Spec:

https://segment.com/docs/spec/common/

I've mapped almost all of the supported ones by Mixpanel except for `$library_version` since they want this to be Mixpanel's library version, not Segment's.

`$brand` is still unclear since it sounds the same as `$manufacturer`. I've updated the fixtures by copying and pasting the entire `context` object from our specs example.

I've also done some refactoring by reorganizing the formatter functions for `properties` and `traits` by separating chunks of context data into its own private functions for better readability.

@f2prateek @sperand-io let me know if you see anything weird!