### PR TITLE
rejecting timestamps older than 5 years

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,10 +29,17 @@ var Mixpanel = module.exports = integration('Mixpanel')
 
 /**
  * Mixpanel requires an `.apiKey` on `track`
- * if the message is older than 5 days.
+ * if the message is older than 5 days. And 
+ * won't import anything older than 5 years.
+ *
+ * https://mixpanel.com/docs/api-documentation/importing-events-older-than-5-days
  */
 
 Mixpanel.ensure(function(msg, settings){
+  var age = Date.now() - msg.timestamp();
+  if (age > ms('5y')) {
+    return this.invalid('message.timestamp() must be within the last five years.');
+  }
   if (settings.apiKey) return;
   if ('track' != msg.type()) return;
   if (!shouldImport(msg)) return;

--- a/test/index.js
+++ b/test/index.js
@@ -54,6 +54,13 @@ describe('Mixpanel', function(){
     it('should be valid when all settings are given', function(){
       test.valid({}, settings);
     });
+
+    it('should be invalid for messages with a timestamp older than five years', function(){
+      test.invalid({
+        type: 'track',
+        timestamp: new Date('5/10/2010')
+      }, settings);
+    });
   });
 
   describe('.identify()', function(){


### PR DESCRIPTION
Mixpanel rejects timestamps older than 5 years, so we should
discard them at our layer:

https://mixpanel.com/docs/api-documentation/importing-events-older-than-5-days