### PR TITLE
fixing empty callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -195,24 +195,22 @@ Mixpanel.prototype.page = function(msg, fn){
 
   // all
   if (this.settings.trackAllPages) {
-    send(msg.track(), fn);
-    return;
+    return send(msg.track(), fn);
   }
 
   // categorized
   if (this.settings.trackCategorizedPages && category) {
-    if (name) {
-      send(msg.track(fullName), fn);
-      return;
-    }
-    send(msg.track(category), fn);
-    return;
+    if (name) return send(msg.track(fullName), fn);
+    return send(msg.track(category), fn);
   }
 
   // named
   if (this.settings.trackNamedPages && name) {
-    send(msg.track(name), fn);
+    return send(msg.track(name), fn);
   }
+
+  // nothing
+  return tick(fn);
 
   // call via track method with `msg`.
   function send(msg, done){

--- a/test/index.js
+++ b/test/index.js
@@ -259,6 +259,22 @@ describe('Mixpanel', function(){
           done();
         });
     });
+
+    it('should not send any requests for disabled pages', function(done){
+      var json = test.fixture('page-named');
+      test
+       .set({
+        trackCategorizedPages: false,
+        trackNamedPages: false,
+        trackAllPages: false
+       })
+       .page(json.input)
+       .end(function(err, res){
+          if (err) return done(err);
+          assert(test.reqs.length == 0);
+          done();
+       });
+    })
   });
 
   describe('.screen()', function(){
@@ -309,6 +325,22 @@ describe('Mixpanel', function(){
           done();
         });
     });
+
+    it('should not send any requests for disabled screens', function(done){
+      var json = test.fixture('screen-named');
+      test
+       .set({
+        trackCategorizedPages: false,
+        trackNamedPages: false,
+        trackAllPages: false
+       })
+       .page(json.input)
+       .end(function(err, res){
+          if (err) return done(err);
+          assert(test.reqs.length == 0);
+          done();
+       });
+    })
   });
 });
 


### PR DESCRIPTION
If a project had no pages or screens enabled, it would cause the
message to hang when no callback was called