### PR TITLE
update fixture timestamps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -470,7 +470,6 @@ function formatProperties(track, settings){
 
   // Map UTM params
   if (campaign) {
-    properties.utm_name = campaign.name;
     properties.utm_source = campaign.source;
     properties.utm_medium = campaign.medium;
     properties.utm_term = campaign.term;

--- a/test/fixtures/identify-basic.json
+++ b/test/fixtures/identify-basic.json
@@ -5,8 +5,8 @@
     "timestamp": "XXX_GETS_OVERRIDDEN: See spec for details",
     "traits": {
       "company": "Example",
-      "firstName": "john",
-      "lastName": "doe",
+      "firstName": "han",
+      "lastName": "kim",
       "met": "2014-01-01",
       "created": "2013-01-01",
       "phone": "555555",
@@ -23,8 +23,8 @@
     "$time": "XXX_GETS_OVERRIDDEN: See spec for details",
     "$set": {
       "company": "Example",
-      "$first_name": "john",
-      "$last_name": "doe",
+      "$first_name": "han",
+      "$last_name": "kim",
       "met": "2014-01-01T00:00:00.000Z",
       "$created": "2013-01-01T00:00:00",
       "$phone": "555555",

--- a/test/fixtures/identify-device-token-set.json
+++ b/test/fixtures/identify-device-token-set.json
@@ -1,12 +1,12 @@
 {
   "input": {
     "type": "identify",
-    "userId": "user-id",
+    "userId": "999999",
     "timestamp": "XXX_GETS_OVERRIDDEN: See spec for details",
     "traits": {
       "company": "Example",
-      "firstName": "john",
-      "lastName": "doe",
+      "firstName": "Lucius",
+      "lastName": "Severus",
       "met": "2014-01-01",
       "created": "2013-01-01",
       "phone": "555555",
@@ -21,19 +21,19 @@
     }
   },
   "output": {
-    "$distinct_id": "user-id",
+    "$distinct_id": "999999",
     "$token": "50912cd33fd82225ab5ae1c563bd5a7e",
     "$time": "XXX_GETS_OVERRIDDEN: See spec for details",
     "$set": {
       "company": "Example",
-      "$first_name": "john",
-      "$last_name": "doe",
+      "$first_name": "Lucius",
+      "$last_name": "Severus",
       "met": "2014-01-01T00:00:00.000Z",
       "$created": "2013-01-01T00:00:00",
       "$phone": "555555",
       "$email": "jd@example.com",
       "trait": "some-trait",
-      "id": "user-id"
+      "id": "999999"
     },
     "$ip": "0.0.0.0",
     "$ignore_time": false,

--- a/test/fixtures/identify-device-token-union.json
+++ b/test/fixtures/identify-device-token-union.json
@@ -1,12 +1,12 @@
 {
   "input": {
     "type": "identify",
-    "userId": "user-id",
+    "userId": "999999",
     "timestamp": "XXX_GETS_OVERRIDDEN: See spec for details",
     "traits": {
       "company": "Example",
-      "firstName": "john",
-      "lastName": "doe",
+      "firstName": "Lucius",
+      "lastName": "Severus",
       "met": "2014-01-01",
       "created": "2013-01-01",
       "phone": "555555",
@@ -21,7 +21,7 @@
     }
   },
   "output": {
-    "$distinct_id": "user-id",
+    "$distinct_id": "999999",
     "$token": "50912cd33fd82225ab5ae1c563bd5a7e",
     "$time": "XXX_GETS_OVERRIDDEN: See spec for details",
     "$union": {

--- a/test/fixtures/page-all.json
+++ b/test/fixtures/page-all.json
@@ -4,19 +4,19 @@
   },
   "input": {
     "type": "page",
-    "userId": "user-id",
-    "timestamp": "2014",
+    "userId": "999999",
+    "timestamp": "2016",
     "properties": {},
     "context": {}
   },
   "output": {
     "event": "Loaded a Page",
     "properties": {
-      "distinct_id": "user-id",
-      "id": "user-id",
-      "mp_name_tag": "user-id",
+      "distinct_id": "999999",
+      "id": "999999",
+      "mp_name_tag": "999999",
       "mp_lib": "Segment: unknown",
-      "time": 1388534400,
+      "time": 1451606400,
       "token": "50912cd33fd82225ab5ae1c563bd5a7e"
     }
   }

--- a/test/fixtures/page-categorized.json
+++ b/test/fixtures/page-categorized.json
@@ -4,8 +4,8 @@
   },
   "input": {
     "type": "page",
-    "userId": "user-id",
-    "timestamp": "2014",
+    "userId": "999999",
+    "timestamp": "2016",
     "category": "Docs",
     "properties": {
       "url": "https://segment.io/docs/integrations/mixpanel/",
@@ -18,14 +18,14 @@
   "output": {
     "event": "Viewed Docs Page",
     "properties": {
-      "distinct_id": "user-id",
-      "id": "user-id",
-      "mp_name_tag": "user-id",
+      "distinct_id": "999999",
+      "id": "999999",
+      "mp_name_tag": "999999",
       "category": "Docs",
       "ip": "0.0.0.0",
       "property": true,
       "mp_lib": "Segment: unknown",
-      "time": 1388534400,
+      "time": 1451606400,
       "token": "50912cd33fd82225ab5ae1c563bd5a7e",
       "url": "https://segment.io/docs/integrations/mixpanel/"
     }

--- a/test/fixtures/page-named.json
+++ b/test/fixtures/page-named.json
@@ -4,8 +4,8 @@
   },
   "input": {
     "type": "page",
-    "userId": "user-id",
-    "timestamp": "2014",
+    "userId": "999999",
+    "timestamp": "2016",
     "category": "Docs",
     "name": "Mixpanel",
     "properties": {
@@ -19,15 +19,15 @@
   "output": {
     "event": "Viewed Mixpanel Page",
     "properties": {
-      "distinct_id": "user-id",
-      "id": "user-id",
-      "mp_name_tag": "user-id",
+      "distinct_id": "999999",
+      "id": "999999",
+      "mp_name_tag": "999999",
       "category": "Docs",
       "ip": "0.0.0.0",
       "name": "Mixpanel",
       "property": true,
       "mp_lib": "Segment: unknown",
-      "time": 1388534400,
+      "time": 1451606400,
       "token": "50912cd33fd82225ab5ae1c563bd5a7e",
       "url": "https://segment.io/docs/integrations/mixpanel/"
     }

--- a/test/fixtures/screen-all.json
+++ b/test/fixtures/screen-all.json
@@ -4,19 +4,19 @@
   },
   "input": {
     "type": "screen",
-    "userId": "user-id",
-    "timestamp": "2014",
+    "userId": "999999",
+    "timestamp": "2016",
     "properties": {},
     "context": {}
   },
   "output": {
     "event": "Loaded a Screen",
     "properties": {
-      "distinct_id": "user-id",
-      "id": "user-id",
-      "mp_name_tag": "user-id",
+      "distinct_id": "999999",
+      "id": "999999",
+      "mp_name_tag": "999999",
       "mp_lib": "Segment: unknown",
-      "time": 1388534400,
+      "time": 1451606400,
       "token": "50912cd33fd82225ab5ae1c563bd5a7e"
     }
   }

--- a/test/fixtures/screen-categorized.json
+++ b/test/fixtures/screen-categorized.json
@@ -4,8 +4,8 @@
   },
   "input": {
     "type": "screen",
-    "userId": "user-id",
-    "timestamp": "2014",
+    "userId": "999999",
+    "timestamp": "2016",
     "category": "Docs",
     "properties": {
       "url": "https://segment.io/docs/integrations/mixpanel/",
@@ -18,14 +18,14 @@
   "output": {
     "event": "Viewed Docs Screen",
     "properties": {
-      "distinct_id": "user-id",
-      "id": "user-id",
-      "mp_name_tag": "user-id",
+      "distinct_id": "999999",
+      "id": "999999",
+      "mp_name_tag": "999999",
       "category": "Docs",
       "ip": "0.0.0.0",
       "property": true,
       "mp_lib": "Segment: unknown",
-      "time": 1388534400,
+      "time": 1451606400,
       "token": "50912cd33fd82225ab5ae1c563bd5a7e",
       "url": "https://segment.io/docs/integrations/mixpanel/"
     }

--- a/test/fixtures/screen-named.json
+++ b/test/fixtures/screen-named.json
@@ -4,8 +4,8 @@
   },
   "input": {
     "type": "screen",
-    "userId": "user-id",
-    "timestamp": "2014",
+    "userId": "999999",
+    "timestamp": "2016",
     "category": "Docs",
     "name": "Mixpanel",
     "properties": {
@@ -19,15 +19,15 @@
   "output": {
     "event": "Viewed Mixpanel Screen",
     "properties": {
-      "distinct_id": "user-id",
-      "id": "user-id",
-      "mp_name_tag": "user-id",
+      "distinct_id": "999999",
+      "id": "999999",
+      "mp_name_tag": "999999",
       "category": "Docs",
       "ip": "0.0.0.0",
       "name": "Mixpanel",
       "property": true,
       "mp_lib": "Segment: unknown",
-      "time": 1388534400,
+      "time": 1451606400,
       "token": "50912cd33fd82225ab5ae1c563bd5a7e",
       "url": "https://segment.io/docs/integrations/mixpanel/"
     }

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -1,8 +1,8 @@
 {
   "input": {
     "type": "track",
-    "userId": "user-id",
-    "event": "my-event",
+    "userId": "999999",
+    "event": "Teemo Rules",
     "timestamp": "2014",
     "properties": {
       "searchEngine": "google",
@@ -17,11 +17,15 @@
       "os": {
         "name": "iPhone OS",
         "version": "8.1.3"
+      },
+      "library": {
+        "name": "analytics.js",
+        "version": "2.11.1"
       }
     }
   },
   "output": {
-    "event": "my-event",
+    "event": "Teemo Rules",
     "properties": {
       "$search_engine": "google",
       "$referrer": "someone",
@@ -31,14 +35,14 @@
       "$browser_version": "7.1.0.7",
       "$username": "jd",
       "email": "jd@example.com",
-      "mp_name_tag": "user-id",
-      "mp_lib": "Segment: unknown",
+      "mp_name_tag": "999999",
+      "mp_lib": "Segment: analytics.js",
       "query": "analytics",
       "ip": "10.0.0.1",
       "time": 1388534400,
-      "id": "user-id",
+      "id": "999999",
       "token": "50912cd33fd82225ab5ae1c563bd5a7e",
-      "distinct_id": "user-id"
+      "distinct_id": "999999"
     }
   }
 }

--- a/test/fixtures/track-context.json
+++ b/test/fixtures/track-context.json
@@ -1,9 +1,9 @@
 {
   "input": {
     "type": "track",
-    "userId": "user-id",
-    "event": "my-event",
-    "timestamp": "2014",
+    "userId": "999999",
+    "event": "HELLO6",
+    "timestamp": "2016",
     "context": {
       "app": {
       "name": "InitechGlobal",
@@ -71,18 +71,18 @@
     }
   },
   "output": {
-    "event": "my-event",
+    "event": "HELLO6",
     "properties": { 
       "$app_release": "3.0.1.545",
       "$app_version": "545",
       "$current_url": "https://segment.com/academy/",
       "$device": "maguro",
-      "distinct_id": "user-id",
+      "distinct_id": "999999",
       "ip": "8.8.8.8",
       "mp_lib": "Segment: analytics.js",
-      "time": 1388534400,
+      "time": 1451606400,
       "token": "50912cd33fd82225ab5ae1c563bd5a7e",
-      "mp_name_tag": "user-id",
+      "mp_name_tag": "999999",
       "$browser": "Mobile Safari",
       "$browser_version": "9.0",
       "$carrier": "T-Mobile NL",
@@ -98,12 +98,11 @@
       "$ios_app_release": "3.0.1.545",
       "$ios_app_version": "545",
       "$ios_version": "8.1.3",
-      "utm_name": "TPS Innovation Newsletter",
       "utm_source": "Newsletter",
       "utm_medium": "email",
       "utm_term": "tps reports",
       "utm_content": "image link",
-      "id": "user-id"
+      "id": "999999"
     }
   }
 }


### PR DESCRIPTION
updated timestamps on the fixtures from 2014 to 2016 so its easier to see the events in MP's live view when debugging.

also updated it so we don't send `utm_name`, that is not a mapped property inside Mixpanel.

@f2prateek I'll redploy once you merge!