### PR TITLE
fix utm bug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -147,7 +147,6 @@ Mixpanel.prototype.track = function(track, fn){
     data: b64encode(payload),
     api_key: this.settings.apiKey
   };
-
   // increment
   if (this.settings.people) {
     batch.push(function(fn){
@@ -434,9 +433,9 @@ function formatProperties(track, settings){
   var properties = track.properties() || {};
   var identify = track.identify();
   var userAgent = track.userAgent();
-  var campaign = track.proxy('context.campaign') || {};
+  var campaign = track.proxy('context.campaign') || undefined;
   var app = track.proxy('context.app') || {};
-
+  
   extend(properties, {
     $app_release: app.build,
     $app_version: app.version,


### PR DESCRIPTION
The `{}` is truthy so it was incorrectly passing the conditional `if` statement, causing UTM props that were sent via properties to not be tracked.